### PR TITLE
Win features

### DIFF
--- a/src/lexdb.h
+++ b/src/lexdb.h
@@ -25,7 +25,11 @@
 #ifndef RULEXDB_H
 #define RULEXDB_H
 
+#ifdef _WIN32
+#include <pcre2posix.h>
+#else
 #include <regex.h>
+#endif
 #include <db.h>
 
 /* BEGIN_C_DECLS should be used at the beginning of C declarations,

--- a/src/lexholder.c
+++ b/src/lexholder.c
@@ -31,7 +31,11 @@
 #define NO_DB_FILE 2
 
 
-static const char *charset = "ru_RU.koi8r";
+#ifdef _WIN32
+  static const char *charset = "Russian_Russia.20866";
+#else
+  static const char *charset = "ru_RU.koi8r";
+#endif
 
 static const char *usage =
 "Lexical database holding utility.\n\n"

--- a/src/rulex.c
+++ b/src/rulex.c
@@ -29,7 +29,11 @@
 #include "lexdb.h"
 
 
-static const char *charset = "ru_RU.koi8r";
+#ifdef _WIN32
+  static const char *charset = "Russian_Russia.20866";
+#else
+  static const char *charset = "ru_RU.koi8r";
+#endif
 
 static const char symbols[] =
   {


### PR DESCRIPTION
Добавлена поддержка koi8 для windows.
Для регулярных выражений, в windows используется библиотека pcre2-posix.
При сборке нужно указать линкеру в качестве библиотек pcre2-posix и pcre2-8.
Также, чтобы статически прилинковать PCRE2, нужно компилятору указать препроцессор команду PCRE2_STATIC.
Пока собрать rulex в Windows штатным makefile не получится, но если собрать иным способом, то получается рабочий продукт.
