### PR TITLE
Add LMDB backend (enabled by default)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,10 +21,26 @@ AC_PROG_INSTALL
 AC_LANG([C])
 AX_CHECK_VSCRIPT
 
+AC_ARG_WITH([bdb],
+  [AS_HELP_STRING([--with-bdb], [use Berkeley DB backend instead of LMDB])],
+  [use_bdb=$withval], [use_bdb=no])
+
 # Checks for required headers and libraries.
 AC_CHECK_HEADERS([stdlib.h unistd.h string.h stdio.h fcntl.h limits.h sys/types.h sys/stat.h], [],
                  [AC_MSG_ERROR([Some system header files are not found])])
-AX_BERKELEY_DB([5.1], [], [AC_MSG_ERROR([Berkeley DB library is mandatory])])
+
+AS_IF([test "x$use_bdb" = "xyes"],
+  [AX_BERKELEY_DB([5.1],
+     [AC_DEFINE([USE_BDB], [1], [Use Berkeley DB backend])],
+     [AC_MSG_ERROR([Berkeley DB >= 5.1 not found])])],
+  [PKG_CHECK_MODULES([LMDB], [lmdb],
+     [],
+     [AC_CHECK_HEADERS([lmdb.h], [],
+        [AC_MSG_ERROR([LMDB header lmdb.h not found])])
+      AC_CHECK_LIB([lmdb], [mdb_env_create], [LMDB_LIBS="-llmdb"],
+        [AC_MSG_ERROR([LMDB library not found])])])])
+
+AM_CONDITIONAL([USE_BDB], [test "x$use_bdb" = "xyes"])
 CHECK_FOR_LOCALES_SUPPORT
 
 # Output results.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,9 +12,15 @@ rulex_LDADD = librulexdb.la
 lexholder_SOURCES = lexholder.c
 lexholder_LDADD = librulexdb.la
 
-librulexdb_la_CPPFLAGS = $(DB_CPPFLAGS)
-librulexdb_la_LDFLAGS = $(DB_LDFLAGS) -version-info 1:0:1
+librulexdb_la_LDFLAGS = -version-info 1:0:1
+
+if USE_BDB
+librulexdb_la_CPPFLAGS = $(DB_CPPFLAGS) -DUSE_BDB
 librulexdb_la_LIBADD = $(DB_LIBS)
+else
+librulexdb_la_CPPFLAGS = $(LMDB_CFLAGS)
+librulexdb_la_LIBADD = $(LMDB_LIBS)
+endif
 
 if HAVE_VSCRIPT
 librulexdb_la_LDFLAGS += $(VSCRIPT_LDFLAGS),@srcdir@/rulex.vscript

--- a/src/lexdb.c
+++ b/src/lexdb.c
@@ -28,7 +28,11 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef USE_BDB
 #include <fcntl.h>
+#else
+#include <stdint.h>
+#endif
 #include "lexdb.h"
 #include "coder.h"
 
@@ -39,8 +43,13 @@
 #define RULEXDB_NOPREFIX 0x80
 
 /* Data storage methods */
+#ifdef USE_BDB
 #define LEXICON_DB_TYPE DB_BTREE
 #define RULES_DB_TYPE DB_RECNO
+#else
+#define LMDB_MAP_SIZE (64 * 1024 * 1024)
+#define LMDB_MAX_DBS 6
+#endif
 
 
 /* Local data */
@@ -55,6 +64,8 @@ static const char *corrections_db_name = "Corrections";
 
 
 /* Local routines */
+
+#ifdef USE_BDB
 
 static DB *db_open(DB_ENV *env, const char *name, int type, int mode)
      /*
@@ -206,7 +217,60 @@ static char *rule_get(DB *db, int n)
   return inVal.data;
 }
 
-static int rules_init(RULEX_RULESET *rules)
+#else /* !USE_BDB: LMDB helpers */
+
+static unsigned int lmdb_nrecs(MDB_txn *txn, MDB_dbi dbi)
+{
+  MDB_stat st;
+  if (mdb_stat(txn, dbi, &st))
+    return 0;
+  return (unsigned int)st.ms_entries;
+}
+
+static int lmdb_get(MDB_txn *txn, MDB_dbi dbi, const char *key, char *value)
+{
+  int rc;
+  char packed_key[RULEXDB_BUFSIZE];
+  MDB_val inKey, inVal;
+
+  inKey.mv_size = (size_t)pack_key(key, packed_key);
+  if ((signed int)inKey.mv_size <= 0)
+    return RULEXDB_EINVKEY;
+  inKey.mv_data = packed_key;
+  rc = mdb_get(txn, dbi, &inKey, &inVal);
+  switch (rc)
+    {
+      case 0:
+        unpack_data(value, inVal.mv_data, (int)inVal.mv_size);
+        return RULEXDB_SUCCESS;
+      case MDB_NOTFOUND:
+        return RULEXDB_SPECIAL;
+      default:
+        break;
+    }
+  return RULEXDB_FAILURE;
+}
+
+static char *lmdb_rule_get(MDB_txn *txn, MDB_dbi dbi, char *rule_buf, int n)
+{
+  uint32_t recno = (uint32_t)n;
+  MDB_val key, data;
+  size_t len;
+
+  key.mv_data = &recno;
+  key.mv_size = sizeof(uint32_t);
+  if (mdb_get(txn, dbi, &key, &data))
+    return NULL;
+  len = data.mv_size < (size_t)(RULEXDB_BUFSIZE - 1)
+        ? data.mv_size : (size_t)(RULEXDB_BUFSIZE - 1);
+  memcpy(rule_buf, data.mv_data, len);
+  rule_buf[len] = '\0';
+  return rule_buf;
+}
+
+#endif /* USE_BDB */
+
+static int rules_init(RULEXDB *rulexdb, RULEX_RULESET *rules)
      /*
       * Initialize ruleset for subsequent fetching and loading
       * (not for updating).
@@ -217,6 +281,8 @@ static int rules_init(RULEX_RULESET *rules)
       * RULEXDB_EACCESS error code will be returned.
       */
 {
+#ifdef USE_BDB
+  (void)rulexdb;
   if (rules->nrules < 0) /* Cannot be initialized for loading */
     return RULEXDB_EACCESS;
   if (rules->db) /* Already initialized */
@@ -251,9 +317,48 @@ static int rules_init(RULEX_RULESET *rules)
 	}
     }
   return RULEXDB_SUCCESS;
+#else
+  unsigned int flags;
+
+  if (rules->nrules < 0)
+    return RULEXDB_EACCESS;
+  if (rules->dbi_open)
+    return RULEXDB_SUCCESS;
+
+  flags = MDB_INTEGERKEY;
+  if (rulexdb->mode != RULEXDB_SEARCH)
+    flags |= MDB_CREATE;
+
+  if (mdb_dbi_open(rulexdb->txn, rules->db_name, flags, &rules->dbi))
+    {
+      rules->nrules = 0;
+      return RULEXDB_SUCCESS;
+    }
+  rules->dbi_open = 1;
+  rules->nrules = (int)lmdb_nrecs(rulexdb->txn, rules->dbi);
+
+  if (rules->nrules > 0)
+    {
+      rules->pattern = calloc((size_t)rules->nrules, sizeof(regex_t *));
+      if (!rules->pattern)
+        {
+          rules->nrules = -1;
+          return RULEXDB_EMALLOC;
+        }
+      rules->replacement = calloc((size_t)rules->nrules, sizeof(char *));
+      if (!rules->replacement)
+        {
+          free(rules->pattern);
+          rules->pattern = NULL;
+          rules->nrules = -1;
+          return RULEXDB_EMALLOC;
+        }
+    }
+  return RULEXDB_SUCCESS;
+#endif
 }
 
-static int rule_load(RULEX_RULESET *rules, int n)
+static int rule_load(RULEXDB *rulexdb, RULEX_RULESET *rules, int n)
      /*
       * Preload specified rule and turn it into internal representation.
       *
@@ -272,7 +377,12 @@ static int rule_load(RULEX_RULESET *rules, int n)
     return RULEXDB_SUCCESS;
 
   /* Get rule source */
+#ifdef USE_BDB
+  (void)rulexdb;
   rule_src = rule_get(rules->db, n + 1);
+#else
+  rule_src = lmdb_rule_get(rulexdb->txn, rules->dbi, rules->rule_buf, n + 1);
+#endif
   if (!rule_src)
     return RULEXDB_FAILURE;
 
@@ -282,8 +392,13 @@ static int rule_load(RULEX_RULESET *rules, int n)
     return RULEXDB_EMALLOC;
 
   /* Compile pattern */
+#ifdef USE_BDB
   rc = regcomp(rules->pattern[n], strtok(rule_src, " "),
 	       REG_EXTENDED | REG_ICASE);
+#else
+  rc = regcomp(rules->pattern[n], strtok(rules->rule_buf, " "),
+               REG_EXTENDED | REG_ICASE);
+#endif
   if (rc) /* Pattern compiling failure */
     {
       regfree(rules->pattern[n]);
@@ -326,11 +441,15 @@ static void rules_release(RULEX_RULESET *rules)
   rules->pattern = NULL;
   free(rules->replacement);
   rules->replacement = NULL;
+#ifdef USE_BDB
   if (rules->db)
     {
       db_close(rules->db);
       rules->db = NULL;
     }
+#else
+  rules->dbi_open = 0;
+#endif
   rules->nrules = 0;
   return;
 }
@@ -349,11 +468,11 @@ static int lexguess(RULEXDB *rulexdb, const char *s, char *t)
   int i;
   regmatch_t match[2];
 
-  i = rules_init(&rulexdb->rules);
+  i = rules_init(rulexdb, &rulexdb->rules);
   if (i) return i;
 
   for (i = 0; i < rulexdb->rules.nrules; i++)
-    if (!rule_load(&rulexdb->rules, i))
+    if (!rule_load(rulexdb, &rulexdb->rules, i))
       if (!regexec(rulexdb->rules.pattern[i], s, 2, match, 0))
 	{
 	  (void)strncpy(t, s, match[1].rm_eo);
@@ -374,11 +493,11 @@ static int postcorrect(RULEXDB *rulexdb, char *s)
   char *r, *t, *orig;
   regmatch_t match[10];
 
-  i = rules_init(&rulexdb->correctors);
+  i = rules_init(rulexdb, &rulexdb->correctors);
   if (i) return i;
 
   for (i = 0; i < rulexdb->correctors.nrules; i++)
-    if (!rule_load(&rulexdb->correctors, i))
+    if (!rule_load(rulexdb, &rulexdb->correctors, i))
       if (!regexec(rulexdb->correctors.pattern[i], s, 10, match, 0))
 	{
 	  t = s + match[0].rm_so;
@@ -408,6 +527,21 @@ static int postcorrect(RULEXDB *rulexdb, char *s)
   return RULEXDB_SUCCESS;
 }
 
+#ifndef USE_BDB
+/*
+ * Internal helper: reference to one of the two dictionaries.
+ * Holds pointers to the related fields in RULEXDB so that
+ * choose_dictionary() can return a single value callers dereference uniformly.
+ */
+typedef struct
+{
+  MDB_dbi    *dbi;
+  int        *dbi_open;
+  MDB_cursor **cursor;
+} DictHandle;
+#endif
+
+#ifdef USE_BDB
 static DB **choose_dictionary(RULEXDB *rulexdb, const char *key, int item_type)
      /*
       * Choose the dictionary and open it if necessary.
@@ -458,6 +592,64 @@ static DB **choose_dictionary(RULEXDB *rulexdb, const char *key, int item_type)
     *db = db_open(rulexdb->env, db_name, LEXICON_DB_TYPE, rulexdb->mode);
   return db;
 }
+#else
+static DictHandle choose_dictionary(RULEXDB *rulexdb, const char *key, int item_type)
+{
+  DictHandle h = {NULL, NULL, NULL};
+  const char *db_name;
+  unsigned int flags;
+
+  if (!rulexdb)
+    return h;
+
+  switch (item_type)
+    {
+      case RULEXDB_EXCEPTION:
+      case RULEXDB_EXCEPTION_RAW:
+        h.dbi      = &rulexdb->exceptions_dbi;
+        h.dbi_open = &rulexdb->exceptions_dbi_open;
+        h.cursor   = &rulexdb->exceptions_cursor;
+        db_name    = exceptions_db_name;
+        break;
+      case RULEXDB_LEXBASE:
+        h.dbi      = &rulexdb->lexicon_dbi;
+        h.dbi_open = &rulexdb->lexicon_dbi_open;
+        h.cursor   = &rulexdb->lexicon_cursor;
+        db_name    = lexicon_db_name;
+        break;
+      case RULEXDB_DEFAULT:
+        if (key)
+          {
+            if (rulexdb_classify(rulexdb, key) == RULEXDB_SPECIAL)
+              {
+                h.dbi      = &rulexdb->lexicon_dbi;
+                h.dbi_open = &rulexdb->lexicon_dbi_open;
+                h.cursor   = &rulexdb->lexicon_cursor;
+                db_name    = lexicon_db_name;
+              }
+            else
+              {
+                h.dbi      = &rulexdb->exceptions_dbi;
+                h.dbi_open = &rulexdb->exceptions_dbi_open;
+                h.cursor   = &rulexdb->exceptions_cursor;
+                db_name    = exceptions_db_name;
+              }
+          }
+        else return h;
+        break;
+      default:
+        return h;
+    }
+
+  if (!*(h.dbi_open))
+    {
+      flags = (rulexdb->mode != RULEXDB_SEARCH) ? MDB_CREATE : 0;
+      if (!mdb_dbi_open(rulexdb->txn, db_name, flags, h.dbi))
+        *(h.dbi_open) = 1;
+    }
+  return h;
+}
+#endif
 
 static RULEX_RULESET *get_ruleset_handler(RULEXDB *rulexdb, int rule_type)
      /*
@@ -492,10 +684,25 @@ static RULEX_RULESET *choose_ruleset(RULEXDB *rulexdb, int rule_type)
 {
   RULEX_RULESET *rules = get_ruleset_handler(rulexdb, rule_type);
 
+  if (!rules) return NULL;
+#ifdef USE_BDB
   if (!rules->db)
     rules->db = db_open(rules->env, rules->db_name,
 			RULES_DB_TYPE, rulexdb->mode);
   if (rules->db) rules->nrules = -1;
+#else
+  if (!rules->dbi_open)
+    {
+      unsigned int flags = MDB_INTEGERKEY;
+      if (rulexdb->mode != RULEXDB_SEARCH)
+        flags |= MDB_CREATE;
+      if (!mdb_dbi_open(rulexdb->txn, rules->db_name, flags, &rules->dbi))
+        {
+          rules->dbi_open = 1;
+          rules->nrules = -1;
+        }
+    }
+#endif
   return rules;
 }
 
@@ -524,6 +731,8 @@ RULEXDB *rulexdb_open(const char *path, int mode)
 
   if (!rulexdb)
     return NULL;
+
+#ifdef USE_BDB
 
   /* Create database environment */
   if (db_env_create(&rulexdb->env, 0))
@@ -588,6 +797,83 @@ RULEXDB *rulexdb_open(const char *path, int mode)
 	break;
     }
 
+#else /* LMDB */
+
+  /* Check file accessibility according to specified access mode */
+  switch (mode)
+    {
+      case RULEXDB_SEARCH:
+	if (access(path, F_OK | R_OK))
+	  {
+	    free(rulexdb);
+	    return NULL;
+	  }
+	break;
+      case RULEXDB_UPDATE:
+	if (access(path, F_OK | R_OK | W_OK))
+	  {
+	    free(rulexdb);
+	    return NULL;
+	  }
+	break;
+      case RULEXDB_CREATE:
+	if (!access(path, F_OK))
+	  if (access(path, R_OK | W_OK))
+	    {
+	      free(rulexdb);
+	      return NULL;
+	    }
+	break;
+      default:
+	free(rulexdb);
+	return NULL;
+    }
+
+  if (mdb_env_create(&rulexdb->env))
+    {
+      free(rulexdb);
+      return NULL;
+    }
+  if (mdb_env_set_mapsize(rulexdb->env, LMDB_MAP_SIZE) ||
+      mdb_env_set_maxdbs(rulexdb->env, LMDB_MAX_DBS))
+    {
+      mdb_env_close(rulexdb->env);
+      free(rulexdb);
+      return NULL;
+    }
+
+  {
+    unsigned int env_flags = MDB_NOSUBDIR;
+    mdb_mode_t file_mode;
+    unsigned int txn_flags;
+
+    if (mode == RULEXDB_SEARCH)
+      env_flags |= MDB_RDONLY;
+    file_mode = (mode == RULEXDB_CREATE) ? 0644 : 0;
+    if (mdb_env_open(rulexdb->env, path, env_flags, file_mode))
+      {
+	mdb_env_close(rulexdb->env);
+	free(rulexdb);
+	return NULL;
+      }
+
+    txn_flags = (mode == RULEXDB_SEARCH) ? MDB_RDONLY : 0;
+    if (mdb_txn_begin(rulexdb->env, NULL, txn_flags, &rulexdb->txn))
+      {
+	mdb_env_close(rulexdb->env);
+	free(rulexdb);
+	return NULL;
+      }
+  }
+
+  rulexdb->rules.db_name       = rules_db_name;
+  rulexdb->lexclasses.db_name  = lexclasses_db_name;
+  rulexdb->prefixes.db_name    = prefixes_db_name;
+  rulexdb->correctors.db_name  = corrections_db_name;
+  rulexdb->mode = mode;
+
+#endif /* USE_BDB */
+
   return rulexdb;
 }
 
@@ -601,11 +887,26 @@ void rulexdb_close(RULEXDB *rulexdb)
   rules_release(&rulexdb->lexclasses);
   rules_release(&rulexdb->prefixes);
   rules_release(&rulexdb->correctors);
+#ifdef USE_BDB
   if (rulexdb->lexicon_db)
     db_close(rulexdb->lexicon_db);
   if (rulexdb->exceptions_db)
     db_close(rulexdb->exceptions_db);
   (void)rulexdb->env->close(rulexdb->env, 0);
+#else
+  if (rulexdb->lexicon_cursor)
+    mdb_cursor_close(rulexdb->lexicon_cursor);
+  if (rulexdb->exceptions_cursor)
+    mdb_cursor_close(rulexdb->exceptions_cursor);
+  if (rulexdb->txn)
+    {
+      if (rulexdb->mode == RULEXDB_SEARCH)
+	mdb_txn_abort(rulexdb->txn);
+      else
+	mdb_txn_commit(rulexdb->txn);
+    }
+  mdb_env_close(rulexdb->env);
+#endif
   free(rulexdb);
   return;
 }
@@ -630,33 +931,88 @@ int rulexdb_subscribe_rule(RULEXDB *rulexdb, const char *src,
       * error code otherwise.
       */
 {
-  int rc;
-  DBT inKey, inVal;
-  db_recno_t recno;
   RULEX_RULESET *rules = choose_ruleset(rulexdb, rule_type);
 
   if (!rules) return RULEXDB_EPARM;
-  if (!rules->db) return RULEXDB_EACCESS;
-  if (n) /* Explicit rule number */
+
+#ifdef USE_BDB
+  {
+    int rc;
+    DBT inKey, inVal;
+    db_recno_t recno;
+
+    if (!rules->db) return RULEXDB_EACCESS;
+    if (n) /* Explicit rule number */
+      {
+	rc = db_nrecs(rules->db);
+	if (n > (unsigned int)rc) /* Ruleset must be continuous */
+	  return RULEXDB_EINVKEY;
+      }
+    (void)memset(&inKey, 0, sizeof(DBT));
+    (void)memset(&inVal, 0, sizeof(DBT));
+    if (n)
+      {
+	recno = n;
+	inKey.data = &recno;
+	inKey.size = sizeof(db_recno_t);
+      }
+    inVal.data = (char *)src;
+    inVal.size = strlen(src) + 1;
+    rc = rules->db->put(rules->db, NULL, &inKey, &inVal, n ? 0 : DB_APPEND);
+    if (rc)
+      return RULEXDB_FAILURE;
+    return RULEXDB_SUCCESS;
+  }
+#else
+  {
+    int rc;
+    unsigned int count;
+    uint32_t recno;
+    MDB_val key, data;
+    char buf[RULEXDB_BUFSIZE];
+
+    if (!rules->dbi_open) return RULEXDB_EACCESS;
+    count = lmdb_nrecs(rulexdb->txn, rules->dbi);
+
+    if (n == 0)
+      {
+	recno = count + 1;
+	key.mv_data = &recno; key.mv_size = sizeof(uint32_t);
+	data.mv_data = (char *)src; data.mv_size = strlen(src) + 1;
+	rc = mdb_put(rulexdb->txn, rules->dbi, &key, &data, 0);
+	return rc ? RULEXDB_FAILURE : RULEXDB_SUCCESS;
+      }
+
+    if (n > count) return RULEXDB_EINVKEY;
+
+    /* Shift records n..count → n+1..count+1 (backward to avoid overwrite) */
     {
-      rc = db_nrecs(rules->db);
-      if (n > rc) /* Ruleset must be continuous */
-	return RULEXDB_EINVKEY;
+      uint32_t i;
+      for (i = count; i >= n; i--)
+        {
+          uint32_t sk = i, dk = i + 1;
+          MDB_val sv = {sizeof(uint32_t), &sk};
+          size_t len;
+          rc = mdb_get(rulexdb->txn, rules->dbi, &sv, &data);
+          if (rc) return RULEXDB_FAILURE;
+          len = data.mv_size < sizeof(buf) ? data.mv_size : sizeof(buf) - 1;
+          memcpy(buf, data.mv_data, len); buf[len] = '\0';
+          {
+            MDB_val dv = {sizeof(uint32_t), &dk};
+            MDB_val dd = {strlen(buf) + 1, buf};
+            rc = mdb_put(rulexdb->txn, rules->dbi, &dv, &dd, 0);
+            if (rc) return RULEXDB_FAILURE;
+          }
+          if (i == 0) break;
+        }
     }
-  (void)memset(&inKey, 0, sizeof(DBT));
-  (void)memset(&inVal, 0, sizeof(DBT));
-  if (n)
-    {
-      recno = n;
-      inKey.data = &recno;
-      inKey.size = sizeof(db_recno_t);
-    }
-  inVal.data = (char *)src;
-  inVal.size = strlen(src) + 1;
-  rc = rules->db->put(rules->db, NULL, &inKey, &inVal, n ? 0 : DB_APPEND);
-  if (rc)
-    return RULEXDB_FAILURE;
-  return RULEXDB_SUCCESS;
+    recno = n;
+    key.mv_data = &recno; key.mv_size = sizeof(uint32_t);
+    data.mv_data = (char *)src; data.mv_size = strlen(src) + 1;
+    rc = mdb_put(rulexdb->txn, rules->dbi, &key, &data, 0);
+    return rc ? RULEXDB_FAILURE : RULEXDB_SUCCESS;
+  }
+#endif
 }
 
 char * rulexdb_fetch_rule(RULEXDB *rulexdb, int rule_type, int n)
@@ -677,8 +1033,13 @@ char * rulexdb_fetch_rule(RULEXDB *rulexdb, int rule_type, int n)
   RULEX_RULESET *rules = choose_ruleset(rulexdb, rule_type);
 
   if (!rules) return NULL;
+#ifdef USE_BDB
   if (!rules->db) return NULL;
   return rule_get(rules->db, n);
+#else
+  if (!rules->dbi_open) return NULL;
+  return lmdb_rule_get(rulexdb->txn, rules->dbi, rules->rule_buf, n);
+#endif
 }
 
 int rulexdb_remove_rule(RULEXDB *rulexdb, int rule_type, int n)
@@ -696,24 +1057,70 @@ int rulexdb_remove_rule(RULEXDB *rulexdb, int rule_type, int n)
       * error code when failure.
       */
 {
-  int rc;
-  DBT inKey;
-  db_recno_t recno = n;
   RULEX_RULESET *rules = choose_ruleset(rulexdb, rule_type);
 
   if (!rules) return RULEXDB_EPARM;
-  if (!rules->db) return RULEXDB_EACCESS;
-  (void)memset(&inKey, 0, sizeof(DBT));
-  inKey.data = &recno;
-  inKey.size = sizeof(db_recno_t);
-  rc = rules->db->del(rules->db, NULL, &inKey, 0);
-  if (rc)
+
+#ifdef USE_BDB
+  {
+    int rc;
+    DBT inKey;
+    db_recno_t recno = n;
+
+    if (!rules->db) return RULEXDB_EACCESS;
+    (void)memset(&inKey, 0, sizeof(DBT));
+    inKey.data = &recno;
+    inKey.size = sizeof(db_recno_t);
+    rc = rules->db->del(rules->db, NULL, &inKey, 0);
+    if (rc)
+      {
+	if (rc == DB_NOTFOUND)
+	  return RULEXDB_SPECIAL;
+	return RULEXDB_FAILURE;
+      }
+    return RULEXDB_SUCCESS;
+  }
+#else
+  {
+    int rc;
+    unsigned int count;
+    char buf[RULEXDB_BUFSIZE];
+    MDB_val data;
+
+    if (!rules->dbi_open) return RULEXDB_EACCESS;
+    count = lmdb_nrecs(rulexdb->txn, rules->dbi);
+    if (n < 1 || (unsigned int)n > count) return RULEXDB_SPECIAL;
+
+    /* Shift n+1..count → n..count-1 */
     {
-      if (rc == DB_NOTFOUND)
-	return RULEXDB_SPECIAL;
-      return RULEXDB_FAILURE;
+      uint32_t i;
+      for (i = (uint32_t)n + 1; i <= count; i++)
+        {
+          uint32_t sk = i, dk = i - 1;
+          MDB_val sv = {sizeof(uint32_t), &sk};
+          size_t len;
+          rc = mdb_get(rulexdb->txn, rules->dbi, &sv, &data);
+          if (rc) return RULEXDB_FAILURE;
+          len = data.mv_size < sizeof(buf) ? data.mv_size : sizeof(buf) - 1;
+          memcpy(buf, data.mv_data, len); buf[len] = '\0';
+          {
+            MDB_val dv = {sizeof(uint32_t), &dk};
+            MDB_val dd = {strlen(buf) + 1, buf};
+            rc = mdb_put(rulexdb->txn, rules->dbi, &dv, &dd, 0);
+            if (rc) return RULEXDB_FAILURE;
+          }
+        }
     }
-  return RULEXDB_SUCCESS;
+    {
+      uint32_t last = count;
+      MDB_val lk = {sizeof(uint32_t), &last};
+      rc = mdb_del(rulexdb->txn, rules->dbi, &lk, NULL);
+      if (rc == MDB_NOTFOUND) return RULEXDB_SPECIAL;
+      if (rc) return RULEXDB_FAILURE;
+    }
+    return RULEXDB_SUCCESS;
+  }
+#endif
 }
 
 int rulexdb_subscribe_item(RULEXDB *rulexdb, const char *key, const char * value,
@@ -748,6 +1155,8 @@ int rulexdb_subscribe_item(RULEXDB *rulexdb, const char *key, const char * value
 {
   int rc;
   char packed_key[RULEXDB_BUFSIZE], packed_data[RULEXDB_BUFSIZE];
+
+#ifdef USE_BDB
   DBT inKey, inVal;
   DB **db = choose_dictionary(rulexdb, key, item_type);
 
@@ -789,6 +1198,48 @@ int rulexdb_subscribe_item(RULEXDB *rulexdb, const char *key, const char * value
       default:
 	break;
     }
+#else
+  MDB_val inKey, inVal;
+  DictHandle h = choose_dictionary(rulexdb, key, item_type);
+
+  if (!h.dbi) return RULEXDB_EPARM;
+  if (!*(h.dbi_open)) return RULEXDB_EACCESS;
+  inKey.mv_size = (size_t)pack_key(key, packed_key);
+  if ((signed int)inKey.mv_size <= 0)
+    return RULEXDB_EINVKEY;
+  inVal.mv_size = (size_t)pack_data(key, value, packed_data);
+  if ((signed int)inVal.mv_size < 0)
+    return RULEXDB_EINVREC;
+  if (!inVal.mv_size)
+    packed_data[inVal.mv_size++] = 0;
+  inKey.mv_data = packed_key;
+  inVal.mv_data = packed_data;
+  rc = mdb_put(rulexdb->txn, *(h.dbi), &inKey, &inVal, MDB_NOOVERWRITE);
+  if ((item_type == RULEXDB_DEFAULT) && (rc == MDB_KEYEXIST)
+      && (h.dbi == &rulexdb->lexicon_dbi))
+    {
+      h = choose_dictionary(rulexdb, NULL, RULEXDB_EXCEPTION);
+      if (!h.dbi) return RULEXDB_EPARM;
+      if (!*(h.dbi_open)) return RULEXDB_EACCESS;
+      rc = mdb_put(rulexdb->txn, *(h.dbi), &inKey, &inVal, MDB_NOOVERWRITE);
+    }
+  switch (rc)
+    {
+      case 0:
+	return RULEXDB_SUCCESS;
+      case MDB_KEYEXIST:
+	if (overwrite)
+	  {
+	    rc = mdb_put(rulexdb->txn, *(h.dbi), &inKey, &inVal, 0);
+	    if (rc) break;
+	    else return RULEXDB_SPECIAL;
+	  }
+	else return RULEXDB_SPECIAL;
+      default:
+	break;
+    }
+#endif
+
   return RULEXDB_FAILURE;
 }
 
@@ -813,6 +1264,7 @@ int rulexdb_retrieve_item(RULEXDB *rulexdb, const char *key, char *value, int it
       * or an appropriate error code when failure.
       */
 {
+#ifdef USE_BDB
   DB **db = choose_dictionary(rulexdb, key, item_type);
 
   if (!db) return RULEXDB_EPARM;
@@ -820,6 +1272,15 @@ int rulexdb_retrieve_item(RULEXDB *rulexdb, const char *key, char *value, int it
 
   (void)strcpy(value, key);
   return db_get(*db, key, value);
+#else
+  DictHandle h = choose_dictionary(rulexdb, key, item_type);
+
+  if (!h.dbi) return RULEXDB_EPARM;
+  if (!*(h.dbi_open)) return RULEXDB_FAILURE;
+
+  (void)strcpy(value, key);
+  return lmdb_get(rulexdb->txn, *(h.dbi), key, value);
+#endif
 }
 
 int rulexdb_lexbase(RULEXDB *rulexdb, const char *s, char *t, int n)
@@ -838,11 +1299,11 @@ int rulexdb_lexbase(RULEXDB *rulexdb, const char *s, char *t, int n)
   regmatch_t match[2];
 
   if ((n < 1) || (!rulexdb) || (!s) || (!t)) return RULEXDB_EPARM;
-  rc = rules_init(&rulexdb->lexclasses);
+  rc = rules_init(rulexdb, &rulexdb->lexclasses);
   if (rc) return rc;
 
   for (i = n - 1; i < rulexdb->lexclasses.nrules; i++)
-    if ((rc = rule_load(&rulexdb->lexclasses, i)))
+    if ((rc = rule_load(rulexdb, &rulexdb->lexclasses, i)))
       break;
     else if (!regexec(rulexdb->lexclasses.pattern[i], s, 2, match, 0))
       {
@@ -904,26 +1365,36 @@ int rulexdb_search(RULEXDB *rulexdb, const char * key, char *value, int flags)
 {
   int i, j, rc = RULEXDB_SPECIAL;
   char *s;
-  DB **db;
 
   (void)strcpy(value, key);
 
   /* The first stage: looking up in the exceptions dictionary */
   if ((!flags) || (flags & RULEXDB_EXCEPTIONS))
     {
-      db = choose_dictionary(rulexdb, NULL, RULEXDB_EXCEPTION);
+#ifdef USE_BDB
+      DB **db = choose_dictionary(rulexdb, NULL, RULEXDB_EXCEPTION);
       if (!db) return RULEXDB_EPARM;
       if (*db)
 	{
 	  rc = db_get(*db, key, value);
 	  if (rc < 0) return rc;
 	}
+#else
+      DictHandle h = choose_dictionary(rulexdb, NULL, RULEXDB_EXCEPTION);
+      if (!h.dbi) return RULEXDB_EPARM;
+      if (*(h.dbi_open))
+	{
+	  rc = lmdb_get(rulexdb->txn, *(h.dbi), key, value);
+	  if (rc < 0) return rc;
+	}
+#endif
     }
 
   /* The second stage: treating the word as an implicit form */
   if ((rc == RULEXDB_SPECIAL) && ((!flags) || (flags & RULEXDB_FORMS)))
     {
-      db = choose_dictionary(rulexdb, NULL, RULEXDB_LEXBASE);
+#ifdef USE_BDB
+      DB **db = choose_dictionary(rulexdb, NULL, RULEXDB_LEXBASE);
       if (!db) return RULEXDB_EPARM;
       if (*db)
 	{
@@ -955,17 +1426,51 @@ int rulexdb_search(RULEXDB *rulexdb, const char * key, char *value, int flags)
 	  else return RULEXDB_EMALLOC;
 	  free(s);
 	}
+#else
+      DictHandle h = choose_dictionary(rulexdb, NULL, RULEXDB_LEXBASE);
+      if (!h.dbi) return RULEXDB_EPARM;
+      if (*(h.dbi_open))
+	{
+	  s = malloc(strlen(key) + 32);
+	  if (s)
+	    for (i = 1; rc == RULEXDB_SPECIAL; i++)
+	      {
+		i = rulexdb_lexbase(rulexdb, key, s, i);
+		if (!i) break;
+		if (i < 0)
+		  {
+		    free(s);
+		    return i;
+		  }
+		if (strlen(key) < strlen(s))
+		  {
+		    for (j = strlen(key); j < strlen(s); j++)
+		      value[j] ='_';
+		    value[strlen(s)] = 0;
+		  }
+		else value[strlen(key)] = 0;
+		rc = lmdb_get(rulexdb->txn, *(h.dbi), s, value);
+		if (rc < 0)
+		  {
+		    free(s);
+		    return rc;
+		  }
+	      }
+	  else return RULEXDB_EMALLOC;
+	  free(s);
+	}
+#endif
 
       /* Prefix detection stage */
       if ((rc == RULEXDB_SPECIAL) &&
-          !rules_init(&rulexdb->prefixes))
+          !rules_init(rulexdb, &rulexdb->prefixes))
         {
           s = malloc(strlen(key));
           if (s)
             {
               regmatch_t match;
               for (i = 0; (rc == RULEXDB_SPECIAL) && (i < rulexdb->prefixes.nrules); i++)
-                if ((!rule_load(&rulexdb->prefixes, i)) &&
+                if ((!rule_load(rulexdb, &rulexdb->prefixes, i)) &&
                     (!regexec(rulexdb->prefixes.pattern[i], key, 1, &match, 0)) &&
                     (!match.rm_so) &&
                     (match.rm_eo < strlen(key)))
@@ -1016,8 +1521,8 @@ int rulexdb_seq(RULEXDB *rulexdb, char *key, char *value, int item_type, int mod
       * will be applied. To prevent this feature you can specify
       * RULEXDB_EXCEPTION_RAW instead of RULEXDB_EXCEPTION.
       * The last argument specifies direction of the dictionary scanning.
-      * Allowed values are: DB_FIRST, DB_NEXT, DB_PREV or DB_LAST
-      * as defined for the underlying database library.
+      * Allowed values are: RULEXDB_SEQ_FIRST, RULEXDB_SEQ_NEXT,
+      * RULEXDB_SEQ_PREV or RULEXDB_SEQ_LAST.
       *
       * Returns 0 (RULEXDB_SUCCESS) on success, RULEXDB_SPECIAL when
       * no more records can be fetched, or an appropriate error code
@@ -1025,6 +1530,8 @@ int rulexdb_seq(RULEXDB *rulexdb, char *key, char *value, int item_type, int mod
       */
 {
   int rc;
+
+#ifdef USE_BDB
   DBT inKey, inVal;
   DBC *dbc;
   DB **db = choose_dictionary(rulexdb, NULL, item_type);
@@ -1061,6 +1568,39 @@ int rulexdb_seq(RULEXDB *rulexdb, char *key, char *value, int item_type, int mod
       default:
 	break;
     }
+#else
+  MDB_val inKey, inVal;
+  DictHandle h = choose_dictionary(rulexdb, NULL, item_type);
+
+  if (!h.dbi) return RULEXDB_EPARM;
+  if (!*(h.dbi_open)) return RULEXDB_FAILURE;
+  if (!*(h.cursor))
+    {
+      rc = mdb_cursor_open(rulexdb->txn, *(h.dbi), h.cursor);
+      if (rc)
+	{
+	  *(h.cursor) = NULL;
+	  return RULEXDB_FAILURE;
+	}
+    }
+  rc = mdb_cursor_get(*(h.cursor), &inKey, &inVal, (MDB_cursor_op)mode);
+  switch (rc)
+    {
+      case 0:
+	if (unpack_key(inKey.mv_data, (unsigned int)inKey.mv_size,
+		       key, RULEXDB_MAX_KEY_SIZE))
+	  return RULEXDB_FAILURE;
+	(void)strcpy(value, key);
+	unpack_data(value, inVal.mv_data, (int)inVal.mv_size);
+	if (item_type == RULEXDB_EXCEPTION)
+	  return postcorrect(rulexdb, value);
+	return RULEXDB_SUCCESS;
+      case MDB_NOTFOUND:
+	return RULEXDB_SPECIAL;
+      default:
+	break;
+    }
+#endif
   return RULEXDB_FAILURE;
 }
 
@@ -1079,6 +1619,8 @@ int rulexdb_remove_item(RULEXDB *rulexdb, const char *key, int item_type)
 {
   int rc;
   char packed_key[RULEXDB_BUFSIZE];
+
+#ifdef USE_BDB
   DBT inKey;
   DB **db = choose_dictionary(rulexdb, key, item_type);
 
@@ -1096,6 +1638,24 @@ int rulexdb_remove_item(RULEXDB *rulexdb, const char *key, int item_type)
 	return RULEXDB_SPECIAL;
       return RULEXDB_FAILURE;
     }
+#else
+  MDB_val inKey;
+  DictHandle h = choose_dictionary(rulexdb, key, item_type);
+
+  if (!h.dbi) return RULEXDB_EPARM;
+  if (!*(h.dbi_open)) return RULEXDB_EACCESS;
+  inKey.mv_size = (size_t)pack_key(key, packed_key);
+  if ((signed int)inKey.mv_size <= 0)
+    return RULEXDB_EINVKEY;
+  inKey.mv_data = packed_key;
+  rc = mdb_del(rulexdb->txn, *(h.dbi), &inKey, NULL);
+  if (rc)
+    {
+      if (rc == MDB_NOTFOUND)
+	return RULEXDB_SPECIAL;
+      return RULEXDB_FAILURE;
+    }
+#endif
   return RULEXDB_SUCCESS;
 }
 
@@ -1118,6 +1678,8 @@ int rulexdb_remove_this_item(RULEXDB *rulexdb, int item_type)
       */
 {
   int rc;
+
+#ifdef USE_BDB
   DBC *dbc;
   DB **db = choose_dictionary(rulexdb, NULL, item_type);
 
@@ -1132,6 +1694,20 @@ int rulexdb_remove_this_item(RULEXDB *rulexdb, int item_type)
 	return RULEXDB_SPECIAL;
       return RULEXDB_FAILURE;
     }
+#else
+  DictHandle h = choose_dictionary(rulexdb, NULL, item_type);
+
+  if (!h.dbi) return RULEXDB_EPARM;
+  if (!*(h.dbi_open)) return RULEXDB_EACCESS;
+  if (!*(h.cursor)) return RULEXDB_EACCESS;
+  rc = mdb_cursor_del(*(h.cursor), 0);
+  if (rc)
+    {
+      if (rc == MDB_NOTFOUND)
+	return RULEXDB_SPECIAL;
+      return RULEXDB_FAILURE;
+    }
+#endif
   return RULEXDB_SUCCESS;
 }
 
@@ -1183,6 +1759,8 @@ int rulexdb_discard_dictionary(RULEXDB *rulexdb, int item_type)
       */
 {
   int rc;
+
+#ifdef USE_BDB
   u_int32_t n;
   DB **db = choose_dictionary(rulexdb, NULL, item_type);
   DBC *dbc;
@@ -1199,6 +1777,25 @@ int rulexdb_discard_dictionary(RULEXDB *rulexdb, int item_type)
   if (rc)
     return RULEXDB_FAILURE;
   return n;
+#else
+  unsigned int n;
+  MDB_stat st;
+  DictHandle h = choose_dictionary(rulexdb, NULL, item_type);
+
+  if (!h.dbi) return RULEXDB_EPARM;
+  if (!*(h.dbi_open)) return RULEXDB_EACCESS;
+  if (*(h.cursor))
+    {
+      mdb_cursor_close(*(h.cursor));
+      *(h.cursor) = NULL;
+    }
+  rc = mdb_stat(rulexdb->txn, *(h.dbi), &st);
+  n = rc ? 0 : (unsigned int)st.ms_entries;
+  rc = mdb_drop(rulexdb->txn, *(h.dbi), 0);
+  if (rc)
+    return RULEXDB_FAILURE;
+  return (int)n;
+#endif
 }
 
 int rulexdb_load_ruleset(RULEXDB *rulexdb, int rule_type)
@@ -1218,10 +1815,10 @@ int rulexdb_load_ruleset(RULEXDB *rulexdb, int rule_type)
   RULEX_RULESET *rules = get_ruleset_handler(rulexdb, rule_type);
 
   if (!rules) return RULEXDB_EPARM;
-  rc = rules_init(rules);
+  rc = rules_init(rulexdb, rules);
   if (!rc)
     for (i = 0; (i < rules->nrules) && !rc; i++)
-      rc = rule_load(rules, i);
+      rc = rule_load(rulexdb, rules, i);
 
   return rc ? rc : rules->nrules;
 }
@@ -1237,15 +1834,32 @@ int rulexdb_discard_ruleset(RULEXDB *rulexdb, int rule_type)
       */
 {
   int rc;
-  u_int32_t n;
   RULEX_RULESET *rules = choose_ruleset(rulexdb, rule_type);
 
   if (!rules) return RULEXDB_EPARM;
-  if (!rules->db) return RULEXDB_EACCESS;
-  rc = rules->db->truncate(rules->db, NULL, &n, 0);
-  if (rc)
-    return RULEXDB_FAILURE;
-  return n;
+
+#ifdef USE_BDB
+  {
+    u_int32_t n;
+    if (!rules->db) return RULEXDB_EACCESS;
+    rc = rules->db->truncate(rules->db, NULL, &n, 0);
+    if (rc)
+      return RULEXDB_FAILURE;
+    return n;
+  }
+#else
+  {
+    unsigned int n;
+    MDB_stat st;
+    if (!rules->dbi_open) return RULEXDB_EACCESS;
+    rc = mdb_stat(rulexdb->txn, rules->dbi, &st);
+    n = rc ? 0 : (unsigned int)st.ms_entries;
+    rc = mdb_drop(rulexdb->txn, rules->dbi, 0);
+    if (rc)
+      return RULEXDB_FAILURE;
+    return (int)n;
+  }
+#endif
 }
 
 const char *rulexdb_dataset_name(int item_type)

--- a/src/lexdb.h
+++ b/src/lexdb.h
@@ -30,7 +30,12 @@
 #else
 #include <regex.h>
 #endif
+
+#ifdef USE_BDB
 #include <db.h>
+#else
+#include <lmdb.h>
+#endif
 
 /* BEGIN_C_DECLS should be used at the beginning of C declarations,
    so that C++ compilers don't mangle their names.  Use END_C_DECLS at
@@ -85,13 +90,31 @@ BEGIN_C_DECLS
 #define RULEXDB_EXCEPTION_RAW 6
 #define RULEXDB_PREFIX 7
 
+#ifdef USE_BDB
+#define RULEXDB_SEQ_FIRST  DB_FIRST
+#define RULEXDB_SEQ_NEXT   DB_NEXT
+#define RULEXDB_SEQ_PREV   DB_PREV
+#define RULEXDB_SEQ_LAST   DB_LAST
+#else
+#define RULEXDB_SEQ_FIRST  MDB_FIRST
+#define RULEXDB_SEQ_NEXT   MDB_NEXT
+#define RULEXDB_SEQ_PREV   MDB_PREV
+#define RULEXDB_SEQ_LAST   MDB_LAST
+#endif
+
 
 /* Data structures */
 
 typedef struct /* Ruleset handler */
 {
+#ifdef USE_BDB
   DB *db; /* Associated database (dataset) */
   DB_ENV *env; /* Pointer to the database environment */
+#else
+  MDB_dbi dbi;
+  int dbi_open;
+  char rule_buf[RULEXDB_BUFSIZE];
+#endif
   const char *db_name; /* Dataset name */
   regex_t **pattern; /* Array of compiled patterns */
   char **replacement; /* Array of replacement strings */
@@ -104,9 +127,20 @@ typedef struct /* Lexical database handler */
   RULEX_RULESET lexclasses; /* Lexical class defining rules */
   RULEX_RULESET prefixes; /* Word prefixes */
   RULEX_RULESET correctors; /* Correction rules */
+#ifdef USE_BDB
   DB *lexicon_db; /* Dictionary of lexical bases */
   DB *exceptions_db; /* Dictionary of exceptions */
   DB_ENV *env; /* Pointer to the database environment */
+#else
+  MDB_dbi lexicon_dbi;
+  int lexicon_dbi_open;
+  MDB_dbi exceptions_dbi;
+  int exceptions_dbi_open;
+  MDB_cursor *lexicon_cursor;
+  MDB_cursor *exceptions_cursor;
+  MDB_env *env;
+  MDB_txn *txn;
+#endif
   int mode; /* Access mode */
 } RULEXDB;
 
@@ -310,8 +344,8 @@ extern int rulexdb_seq(RULEXDB *rulexdb, char *key, char *value,
  * will be applied. To prevent this feature you can specify
  * RULEXDB_EXCEPTION_RAW instead of RULEXDB_EXCEPTION.
  * The last argument specifies direction of the dictionary scanning.
- * Allowed values are: DB_FIRST, DB_NEXT, DB_PREV or DB_LAST
- * as defined for the underlying database library.
+ * Allowed values are: RULEXDB_SEQ_FIRST, RULEXDB_SEQ_NEXT,
+ * RULEXDB_SEQ_PREV or RULEXDB_SEQ_LAST.
  *
  * Returns 0 (RULEXDB_SUCCESS) on success, RULEXDB_SPECIAL when
  * no more records can be fetched, or an appropriate error code

--- a/src/lexholder.c
+++ b/src/lexholder.c
@@ -320,9 +320,9 @@ int main(int argc, char *argv[])
 			      rulexdb_dataset_name(dataset));
               if (RULEXDB_EXCEPTION == dataset)
                 dataset = RULEXDB_EXCEPTION_RAW;
-	      for (ret = rulexdb_seq(db, key, value, dataset, DB_FIRST);
+	      for (ret = rulexdb_seq(db, key, value, dataset, RULEXDB_SEQ_FIRST);
 		   ret == RULEXDB_SUCCESS;
-		   ret = rulexdb_seq(db, key, value, dataset, DB_NEXT))
+		   ret = rulexdb_seq(db, key, value, dataset, RULEXDB_SEQ_NEXT))
 		{
 		  (void)printf("%s %s\n", key, value);
 		  n++;
@@ -537,9 +537,9 @@ int main(int argc, char *argv[])
         {
           if (dataset == RULEXDB_LEXBASE)
             (void)rulexdb_load_ruleset(db, RULEXDB_PREFIX);
-          for (ret = rulexdb_seq(db, key, value, RULEXDB_LEXBASE, DB_FIRST);
+          for (ret = rulexdb_seq(db, key, value, RULEXDB_LEXBASE, RULEXDB_SEQ_FIRST);
                ret == RULEXDB_SUCCESS;
-               ret = rulexdb_seq(db, key, value, RULEXDB_LEXBASE, DB_NEXT))
+               ret = rulexdb_seq(db, key, value, RULEXDB_LEXBASE, RULEXDB_SEQ_NEXT))
             if (rulexdb_classify(db, key) == RULEXDB_SUCCESS)
               {
                 if (!rulexdb_remove_this_item(db, RULEXDB_LEXBASE))
@@ -553,9 +553,9 @@ int main(int argc, char *argv[])
               }
         }
       if ((dataset == RULEXDB_DEFAULT) || (dataset == RULEXDB_EXCEPTION))
-	for (ret = rulexdb_seq(db, key, value, RULEXDB_EXCEPTION, DB_FIRST);
+	for (ret = rulexdb_seq(db, key, value, RULEXDB_EXCEPTION, RULEXDB_SEQ_FIRST);
 	     ret == RULEXDB_SUCCESS;
-	     ret = rulexdb_seq(db, key, value, RULEXDB_EXCEPTION, DB_NEXT))
+	     ret = rulexdb_seq(db, key, value, RULEXDB_EXCEPTION, RULEXDB_SEQ_NEXT))
 	  {
 	    (void)rulexdb_search(db, key, line, search_mode);
 	    if (!strcmp(line, value))


### PR DESCRIPTION
Due to oracle licensing and problems with the old berkeley db versions on mobile platforms, it was decided to add LMDB backend, another key-value database library with more permissive licensing model.

@poretsky sorry, this code may not be perfect, as it was written in rush and unfortunately due to personal reasons dragging untill now.
I will be glad to get feedback and do necessary changes this pr to be included.

Thanks.